### PR TITLE
Added default widths to the installation script

### DIFF
--- a/installation/sql/mysql/joomla.sql
+++ b/installation/sql/mysql/joomla.sql
@@ -662,7 +662,7 @@ INSERT INTO `#__extensions` (`extension_id`, `package_id`, `name`, `type`, `elem
 (487, 0, 'plg_system_httpheaders', 'plugin', 'httpheaders', 'system', 0, 1, 1, 0, '', '{}', 0, '0000-00-00 00:00:00', 0, 0, ''),
 (488, 0, 'plg_sampledata_multilang', 'plugin', 'multilang', 'sampledata', 0, 1, 1, 0, '', '', 0, '0000-00-00 00:00:00', 0, 0, ''),
 (489, 0, 'plg_extension_namespacemap', 'plugin', 'namespacemap', 'extension', 0, 1, 1, 0, '', '{}', 0, '0000-00-00 00:00:00', 0, 0, ''),
-(490, 0, 'plg_media-action_focus', 'plugin', 'focus', 'media-action', 0, 1, 1, 0, '', '{}', 0, '0000-00-00 00:00:00', 1, 0, ''),
+(490, 0, 'plg_media-action_focus', 'plugin', 'focus', 'media-action', 0, 1, 1, 0, '', '{"customWidth":{"customWidth0":{"width":"240"},"customWidth1":{"width":"360"},"customWidth3":{"width":"480"},"customWidth4":{"width":"720"},"customWidth5":{"width":"860"},"customWidth6":{"width":"940"}}}', 0, '0000-00-00 00:00:00', 1, 0, ''),
 (491, 0, 'plg_content_adaptiveimage', 'plugin', 'adaptiveimage', 'content', 0, 1, 1, 0, '', '{}', 0, '0000-00-00 00:00:00', 0, 0, ''),
 (509, 0, 'atum', 'template', 'atum', '', 1, 1, 1, 0, '', '', 0, '0000-00-00 00:00:00', 0, 0, ''),
 (510, 0, 'cassiopeia', 'template', 'cassiopeia', '', 0, 1, 1, 0, '', '{"logoFile":"","fluidContainer":"0","sidebarLeftWidth":"3","sidebarRightWidth":"3"}', 0, '0000-00-00 00:00:00', 0, 0, ''),

--- a/installation/sql/postgresql/joomla.sql
+++ b/installation/sql/postgresql/joomla.sql
@@ -675,7 +675,7 @@ INSERT INTO "#__extensions" ("extension_id", "package_id", "name", "type", "elem
 (487, 0, 'plg_system_httpheaders', 'plugin', 'httpheaders', 'system', 0, 1, 1, 0, '', '{}', 0, '1970-01-01 00:00:00', 0, 0, ''),
 (488, 0, 'plg_sampledata_multilang', 'plugin', 'multilang', 'sampledata', 0, 1, 1, 0, '', '', 0, '0000-00-00 00:00:00', 0, 0, ''),
 (489, 0, 'plg_extension_namespacemap', 'plugin', 'namespacemap', 'extension', 0, 1, 1, 0, '', '{}', 0, '1970-01-01 00:00:00', 0, 0, ''),
-(490, 0, 'plg_media-action_focus', 'plugin', 'focus', 'media-action', 0, 1, 1, 0, '', '{}', 0, '0000-00-00 00:00:00', 1, 0, ''),
+(490, 0, 'plg_media-action_focus', 'plugin', 'focus', 'media-action', 0, 1, 1, 0, '', '{"customWidth":{"customWidth0":{"width":"240"},"customWidth1":{"width":"360"},"customWidth3":{"width":"480"},"customWidth4":{"width":"720"},"customWidth5":{"width":"860"},"customWidth6":{"width":"940"}}}', 0, '0000-00-00 00:00:00', 1, 0, ''),
 (491, 0, 'plg_content_adaptiveimage', 'plugin', 'adaptiveimage', 'content', 0, 1, 1, 0, '', '{}', 0, '0000-00-00 00:00:00', 0, 0, ''),
 (600, 802, 'English (en-GB)', 'language', 'en-GB', '', 0, 1, 1, 1, '', '', 0, '1970-01-01 00:00:00', 0, 0, ''),
 (601, 802, 'English (en-GB)', 'language', 'en-GB', '', 1, 1, 1, 1, '', '', 0, '1970-01-01 00:00:00', 0, 0, ''),


### PR DESCRIPTION
Pull Request for Issue #16 

### Summary of Changes

Default widths are being added to the plugin during installation.

### Testing Instructions

- Fresh Install Joomla
- Go to Site Administrator -> Extensions -> Plugin -> Media-Action Focus.
- You would be seeing all the default widths

#### Screenshot
![screenshot 55](https://user-images.githubusercontent.com/18314265/44037029-f5e88b04-9f30-11e8-9e02-d3bff41232d2.png)
